### PR TITLE
Fix code in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or using a *script* tag
 then
 ```js
 const myLine = new THREE.Line(
-  new THREE.GeoJsonGeometry(geoJson),
+  new GeoJsonGeometry(geoJson),
   new THREE.LineBasicMaterial({ color: 'blue' })
 );
 


### PR DESCRIPTION
GeoJsonGeometry is not part of the THREE module.