### PR TITLE
fix: package.json types for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "dist/three-geojson-geometry.mjs",
   "types": "dist/three-geojson-geometry.d.ts",
   "exports": {
+    "types": "./dist/three-geojson-geometry.d.ts",
     "umd": "./dist/three-geojson-geometry.min.js",
     "default": "./dist/three-geojson-geometry.mjs"
   },


### PR DESCRIPTION
Fix package.json types for esm/node16 resolution

check https://arethetypeswrong.github.io/?p=three-geojson-geometry%401.3.2 for more info